### PR TITLE
Upgrade  `oj` gem to 3.* to support Ruby 2.7 and above

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    wave_to_json (0.0.1)
-      oj (~> 2.0)
+    wave_to_json (0.0.2)
+      oj (~> 3.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    oj (2.1.4)
+    oj (3.14.2)
     rake (10.1.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -26,3 +26,4 @@ DEPENDENCIES
   rake
   rspec
   wave_to_json!
+  

--- a/lib/wave_to_json/version.rb
+++ b/lib/wave_to_json/version.rb
@@ -1,3 +1,3 @@
 class WaveToJson
-  VERSION="0.0.1"
+  VERSION="0.0.2"
 end

--- a/wave_to_json.gemspec
+++ b/wave_to_json.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency     "oj", "~> 2.0"
+  s.add_runtime_dependency     "oj", "~> 3.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Seeing this error after upgrading to Ruby 2.7.

Recommendation as per the below threads is to update `oj` to 3.*.

https://github.com/ohler55/oj/discussions/916
https://gitlab.com/gitlab-com/www-gitlab-com/-/merge_requests/133810

```Fetching gem metadata from https://rubygems.org/.........
Installing oj 2.18.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/oj-2.18.5/ext/oj
/Users/.asdf/installs/ruby/2.7.8/bin/ruby -I /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0 -r ./siteconf20240729-70383-1tq7ljb.rb extconf.rb
>>>>> Creating Makefile for ruby version 2.7.8 on arm64-darwin23 <<<<<
creating Makefile

current directory: /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/oj-2.18.5/ext/oj
make "DESTDIR=" clean

current directory: /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/oj-2.18.5/ext/oj
make "DESTDIR="
compiling cache8.c
compiling circarray.c
compiling compat.c
compiling dump.c
dump.c:1067:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int (*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)')
[-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_object, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/.asdf/installs/ruby/2.7.8/include/ruby-2.7.0/ruby/intern.h:558:35: note: passing argument to parameter here
void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE);
                                  ^
dump.c:1069:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int (*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)')
[-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_compat, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/.asdf/installs/ruby/2.7.8/include/ruby-2.7.0/ruby/intern.h:558:35: note: passing argument to parameter here
void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE);
                                  ^
dump.c:1071:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int (*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)')
[-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_strict, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/.asdf/installs/ruby/2.7.8/include/ruby-2.7.0/ruby/intern.h:558:35: note: passing argument to parameter here
void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE);
                                  ^
dump.c:1745:23: error: incompatible function pointer types passing 'int (ID, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int (*)(ID, VALUE, st_data_t)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)')
[-Wincompatible-function-pointer-types]
        rb_ivar_foreach(obj, dump_attr_cb, (VALUE)out);
                             ^~~~~~~~~~~~
/Users/.asdf/installs/ruby/2.7.8/include/ruby-2.7.0/ruby/intern.h:986:35: note: passing argument to parameter here
void rb_ivar_foreach(VALUE, int (*)(ID, VALUE, st_data_t), st_data_t);
                                  ^
4 errors generated.
make: *** [dump.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/oj-2.18.5 for inspection.
Results logged to /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/extensions/arm64-darwin-23/2.7.0/oj-2.18.5/gem_make.out

  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:99:in `run'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:51:in `block in make'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:43:in `each'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:43:in `make'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:63:in `block in build'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/tempfile.rb:291:in `open'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:30:in `build'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:169:in `block in build_extension'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:165:in `synchronize'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:165:in `build_extension'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:210:in `block in build_extensions'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:207:in `each'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/ext/builder.rb:207:in `build_extensions'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/2.7.0/rubygems/installer.rb:844:in `build_extensions'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/rubygems_gem_installer.rb:76:in `build_extensions'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/source/rubygems.rb:203:in `install'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:130:in `do_install'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/installer/parallel_installer.rb:121:in `block in worker_pool'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/worker.rb:62:in `apply_func'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in `loop'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/worker.rb:54:in `process_queue'
  /Users/.asdf/installs/ruby/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing oj (2.18.5), and Bundler cannot continue.

In Gemfile:
  queue_client was resolved to 3.6.1, which depends on
    oj```